### PR TITLE
binder: add jupyter-packaging

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - python >=3.8,<3.9.0a0
   - jupyterlab >=3,<4.0.0a0
   # labextension build dependencies
+  - jupyter-packaging
   - nodejs >=14,<15
   - pip
   - wheel


### PR DESCRIPTION
Without this mybinder fails:
```
...
+ jupyter labextension develop . --overwrite
Traceback (most recent call last):
  File "setup.py", line 6, in <module>
    from jupyter_packaging import get_data_files
ModuleNotFoundError: No module named 'jupyter_packaging'
An error occurred.
FileNotFoundError: The Python package `.` is not a valid package, it is missing the `setup.py` file.
See the log file for details:  /tmp/jupyterlab-debug-7867nnoh.log
Removing intermediate container e419e63a16fc
The command '/bin/sh -c ./.binder/postBuild' returned a non-zero code: 1
```