### PR TITLE
Feat: add Trove classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,11 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Framework :: Jupyter
+    Framework :: Jupyter :: JupyterLab
+    Framework :: Jupyter :: JupyterLab :: 3
+    Framework :: Jupyter :: JupyterLab :: Extensions
+    Framework :: Jupyter :: JupyterLab :: Extensions :: Mime Renderers
+    Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt
 keywords =
     Jupyter
     JupyterLab


### PR DESCRIPTION
@bollwyvl what do you think RE the `Mime Renderers` classifier? We aren't "technically" a mime-renderer extension, but we do *technically* add a mime-renderer (by overwriting `markdownRendererFactory.createRenderer`).