### PR TITLE
use Mode.ensure for CodeMirror modes

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -288,6 +288,10 @@ export class MarkdownItManager implements IMarkdownIt {
         return;
       }
 
+      Mode.ensure(spec).catch(err =>
+        console.warn(`Failed to load CodeMirror mode ${lang}:`, spec, err)
+      );
+
       const el = document.createElement('div');
       try {
         Mode.run(str, spec.mime, el);

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -156,6 +156,11 @@ export class MarkdownItManager implements IMarkdownIt {
     const preParseHooks: IMarkdownIt.IHook<string, string>[] = [];
     const postRenderHooks: IMarkdownIt.IHook<HTMLElement, void>[] = [];
 
+    // add mode pre-loading hook if using default highlighter
+    if (this.highlightCode === allOptions.highlight) {
+      preParseHooks.push(this.getModePreloader());
+    }
+
     // Build MarkdownIt and load lifecycle hooks
     for (const provider of pluginProviders) {
       if (this.userDisabledPlugins.indexOf(provider.id) !== -1) {
@@ -273,6 +278,29 @@ export class MarkdownItManager implements IMarkdownIt {
   }
 
   /**
+   * A `preParse` hook which preloads CodeMirror modes.
+   */
+  protected getModePreloader(): IMarkdownIt.IHook<string, string> {
+    const fenced = new RegExp(/^[~`]{3}([^\s]+)/g);
+
+    return {
+      run: async source => {
+        let newModes = new Map<string, Promise<any>>();
+        let match: RegExpMatchArray;
+        while ((match = fenced.exec(source))) {
+          if (!newModes.has(match[1])) {
+            newModes.set(match[1], Mode.ensure(match[1]));
+          }
+        }
+        if (newModes.size) {
+          Promise.all(newModes.values()).catch(console.warn);
+        }
+        return source;
+      }
+    };
+  }
+
+  /**
    * Use CodeMirror to highlight code blocks,
    *
    * NOTE: May be overridden by plugins
@@ -287,10 +315,6 @@ export class MarkdownItManager implements IMarkdownIt {
         console.warn(`No CodeMirror mode: ${lang}`);
         return;
       }
-
-      Mode.ensure(spec).catch(err =>
-        console.warn(`Failed to load CodeMirror mode ${lang}:`, spec, err)
-      );
 
       const el = document.createElement('div');
       try {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -285,7 +285,7 @@ export class MarkdownItManager implements IMarkdownIt {
 
     return {
       run: async source => {
-        let newModes = new Map<string, Promise<any>>();
+        const newModes = new Map<string, Promise<any>>();
         let match: RegExpMatchArray;
         while ((match = fenced.exec(source))) {
           if (!newModes.has(match[1])) {


### PR DESCRIPTION
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bollwyvl/jupyterlab-markup/gh-48-mode-ensure)

## Elevator Pitch

Uses `Mode.ensure` to attempt loading every encountered `CodeMirror` block.

## References

- fixes #48 (sort of)

## Changes

- [x] if the default highlighter is used, installs a `preParse` hook which calls `Mode.ensure` for each found fenced code block header

## Follow-on Work

Some of this could occur on this PR or elsewhere:

- may want to cache what has already had `Mode.ensure` called _between_ rendering runs  to avoid excessive re-loading
  - however, this could potentially introduce more race conditions
  - maybe just remembering the successful ones